### PR TITLE
Change desert warp point to avoid triggering bus animation

### DIFF
--- a/FastTravel/config.json
+++ b/FastTravel/config.json
@@ -3,7 +3,7 @@
     {
       "MapName": "Calico Desert",
       "GameLocationIndex": 28,
-      "SpawnPosition": "18, 29",
+      "SpawnPosition": "19, 41",
       "RerouteName": "Desert"
     },
     {


### PR DESCRIPTION
This pull request moves the desert warp point to avoid triggering the bus animation. (The animation plays if the Y coordinate is between 10 and 40.)