### PR TITLE
Standardise update key format

### DIFF
--- a/FastTravel/manifest.json
+++ b/FastTravel/manifest.json
@@ -6,5 +6,5 @@
   "UniqueID": "DeathGameDev.FastTravel",
   "EntryDll": "FastTravel.dll",
   "MinimumApiVersion": "2.6-beta",
-  "UpdateKeys": [ "Nexus: 1529" ]
+  "UpdateKeys": [ "Nexus:1529" ]
 }


### PR DESCRIPTION
This PR just changes `Nexus: 1529` in the manifest to `Nexus:1529`, to avoid issues for non-SMAPI tools which parse manifests.