### PR TITLE
Update to Stardew 1.6 and Smapi 4.0.0: Fix compile errors

### DIFF
--- a/FastTravel/CommandHandler.cs
+++ b/FastTravel/CommandHandler.cs
@@ -50,7 +50,7 @@ namespace FastTravel
             report.AppendLine("This location ID can be used on 'GameLocationIndex' field, on config.json\n");
             foreach (var location in Game1.locations)
             {
-                report.AppendLine($"  ID: {Game1.locations.IndexOf(location)} / Name: {location.name}");
+                report.AppendLine($"  ID: {Game1.locations.IndexOf(location)} / Name: {location.Name}");
             }
             report.AppendLine("################");
             this.Monitor.Log(report.ToString(), LogLevel.Info);
@@ -64,7 +64,7 @@ namespace FastTravel
             report.AppendLine("\n#### PLAYER LOCATION ####");
             report.AppendLine("The tile position X and Y, you can be used on 'SpawnPosition' field, on config.json\n");
             report.AppendLine($"  - currentLocation.Name: {Game1.currentLocation.Name}");
-            report.AppendLine($"  - player tile position: X => {Game1.player.getTileX()} | Y => {Game1.player.getTileY()}");
+            report.AppendLine($"  - player tile position: X => {Game1.player.Tile.X} | Y => {Game1.player.Tile.Y}");
             report.AppendLine("################");
             this.Monitor.Log(report.ToString(), LogLevel.Info);
         }

--- a/FastTravel/FastTravel.csproj
+++ b/FastTravel/FastTravel.csproj
@@ -7,10 +7,11 @@
     <TargetFramework>net452</TargetFramework>
     <Platforms>x86</Platforms>
     <PlatformTarget>x86</PlatformTarget>
+	<GamePath>D:\Program Files\SteamLibrary\steamapps\common\Stardew Valley</GamePath>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="3.0.0-beta.8" />
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/FastTravel/ModEntry.cs
+++ b/FastTravel/ModEntry.cs
@@ -77,7 +77,7 @@ namespace FastTravel
 
 				int x = (int) e.Cursor.ScreenPixels.X;
 				int y = (int) e.Cursor.ScreenPixels.Y;
-                foreach (ClickableComponent point in mapPage.points)
+                foreach (ClickableComponent point in mapPage.points.Values)
 				{
 					// If the player isn't hovering over this point, don't worry about anything.
 					if (!point.containsPoint(x, y))
@@ -184,7 +184,7 @@ namespace FastTravel
 			Thread.Sleep(Consts.MillisecondsToCheckIfWarped);
 
             // Check if we are at the new location and if its a festival day.
-            bool hasFestivalToday = Game1.currentLocation.Name != locName && Utility.isFestivalDay(Game1.dayOfMonth, Game1.currentSeason);
+            bool hasFestivalToday = Game1.currentLocation.Name != locName && Utility.isFestivalDay();
 
             if (hasFestivalToday)
 				Game1.showGlobalMessage(translationHelper.Get("TODAY_HAS_FESTIVAL"));

--- a/FastTravel/manifest.json
+++ b/FastTravel/manifest.json
@@ -1,10 +1,10 @@
 ﻿{
   "Name": "Fast Travel",
   "Author": "@MckenonDev",
-  "Version": "1.3.0",
+  "Version": "1.3.1",
   "Description": "Adds the ability to fast travel to any location on the map",
   "UniqueID": "Mckenon.FastTravel",
   "EntryDll": "FastTravel.dll",
-  "MinimumApiVersion": "2.11.2",
+  "MinimumApiVersion": "4.0.0",
   "UpdateKeys": [ "Nexus:1529" ]
 }


### PR DESCRIPTION
This only fixes the code references to get it to compile. When I try to use it in game, the player ends up in the wrong places. There is either a problem with processing the input (clicking map location), or the new changes to the map in the game means more in-depth code changes are needed in this mod.